### PR TITLE
Update PullToRefreshLayoutRenderer.cs

### DIFF
--- a/PullToRefreshLayout/PullToRefresh/PullToRefresh.Droid/PullToRefreshLayoutRenderer.cs
+++ b/PullToRefreshLayout/PullToRefresh/PullToRefresh.Droid/PullToRefreshLayoutRenderer.cs
@@ -14,6 +14,7 @@
  */
 using System;
 using System.ComponentModel;
+using System.Reflection;
 using Android.Runtime;
 using Android.Support.V4.Widget;
 using Android.Views;

--- a/PullToRefreshLayout/PullToRefresh/PullToRefresh.Droid/PullToRefreshLayoutRenderer.cs
+++ b/PullToRefreshLayout/PullToRefresh/PullToRefresh.Droid/PullToRefreshLayoutRenderer.cs
@@ -107,7 +107,7 @@ namespace Refractored.XamForms.PullToRefresh.Droid
             if (packed != null)
                 RemoveView(packed.ViewGroup);
 
-            packed = RendererFactory.GetRenderer(RefreshView.Content);
+            packed = Platform.CreateRenderer (RefreshView.Content);
 
             try
             {
@@ -136,7 +136,7 @@ namespace Refractored.XamForms.PullToRefresh.Droid
                     return rendererProperty;
 
                 var type = Type.GetType("Xamarin.Forms.Platform.Android.Platform, Xamarin.Forms.Platform.Android");
-                var prop = type.GetField("RendererProperty");
+                var prop = type.GetField("RendererProperty", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static);
                 var val = prop.GetValue(null);
                 rendererProperty = val as BindableProperty;
 


### PR DESCRIPTION
The RendererFactory.GetRenderer function is obsolete now.
The "type.GetField("RendererProperty")" method returns with null, with the latest Xamarin.Android package. I think the property is non-public now, and this fix solves the problem.
